### PR TITLE
[FIX] preferences name: project name is not the same as preference function

### DIFF
--- a/prefs/tp_wepesi_wepesilist.php
+++ b/prefs/tp_wepesi_wepesilist.php
@@ -1,6 +1,6 @@
 <?php
 
-function prefs_tp_wepesi_tiki_demo_list()
+function prefs_tp_wepesi_wepesilist_list()
 {
     return array(
         'tp_wepesi_wepesilist__sample' => [


### PR DESCRIPTION
The project name has been updated, but the preferences function was not, this make the preferences to not be found and generate an error.